### PR TITLE
fix: display of nav toggle button

### DIFF
--- a/src/assets/scss/components/index.scss
+++ b/src/assets/scss/components/index.scss
@@ -111,7 +111,7 @@
 .no-js button {
     display: none !important;
 }
-@media all and (min-width: 680px) {
+@media all and (min-width: 681px) {
     .enhanced #nav-toggle {
         display: none;
     }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [JS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/eslint/blob/HEAD/CONTRIBUTING.md).

#### What is the purpose of this pull request?
The display of toggle button of navbar is none in 680px screen width while the nav-list is also hidden.
![Screenshot 2023-02-02 201820](https://user-images.githubusercontent.com/86398394/216356814-72a2b475-3dd3-46fc-a1c8-821bc1cbf9cb.png)

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
just set the media query min-width to 681px so the display of the toggle button will be none on 681px

#### Related Issues

#### Is there anything you'd like reviewers to focus on?

<!-- markdownlint-disable-file MD004 -->
